### PR TITLE
Fixing OOM during goreleaser build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       - update-go-dependencies
       - run:
           name: Release
-          command: curl -sfL https://goreleaser.com/static/run | bash /dev/stdin release --skip=validate --clean
+          command: curl -sfL https://goreleaser.com/static/run | bash /dev/stdin release --skip=validate --clean -p 4
       - slack/notify:
           channel: -devops
 


### PR DESCRIPTION
By default, it runs 8 parallel builds, and this is too much for the memory we have in Circle

Reduced to 4 (the number of CPUs we have, and what should be the default)