### PR TITLE
Fix nil pointer dereference on pipeline import when RefreshSchedule is nil

### DIFF
--- a/etleap.patch
+++ b/etleap.patch
@@ -759,9 +759,20 @@ index 1acd729..8c62cbe 100644
  	"time"
 +	"reflect"
  )
- 
+
  func (r *PipelineResourceModel) ToSharedPipelineInput() *shared.PipelineInput {
-@@ -7114,6 +7115,12 @@ func (r *PipelineResourceModel) ToSharedPipelineUpdate() *shared.PipelineUpdate
+@@ -3894,5 +3895,8 @@ func (r *PipelineResourceModel) RefreshFromSharedPipelineOutput(resp *shared.Pip
+ 	r.Paused = types.BoolValue(resp.Paused)
+ 	r.PipelineMode = types.StringValue(string(resp.PipelineMode))
++	if r.RefreshSchedule == nil {
++		r.RefreshSchedule = &RefreshScheduleTypes{}
++	}
+ 	if resp.RefreshSchedule.RefreshScheduleModeDaily != nil {
+ 		r.RefreshSchedule.Daily = &UpdateScheduleModeDaily{}
+ 		r.RefreshSchedule.Daily.HourOfDay = types.Int64Value(resp.RefreshSchedule.RefreshScheduleModeDaily.HourOfDay)
+@@ -7156,8 +7160,14 @@ func (r *PipelineResourceModel) ToSharedPipelineUpdate() *shared.PipelineUpdate
+ 	if sourceZuoraUpdate != nil {
+ 		source = &shared.SourceTypesUpdate{
  			SourceZuoraUpdate: sourceZuoraUpdate,
  		}
  	}
@@ -771,10 +782,10 @@ index 1acd729..8c62cbe 100644
 +		nilOutTypeField(source)
 +	}
 +
- 	var refreshSchedule *shared.PipelineUpdateScheduleTypes
- 	if r.RefreshSchedule != nil {
- 		var refreshScheduleModeNeverScheduleTypesNeverScheduleMode *shared.RefreshScheduleModeNeverScheduleTypesNeverScheduleMode
-@@ -7295,3 +7302,31 @@ func (r *PipelineResourceModel) ToSharedPipelineDelete() *shared.PipelineDelete
+ 	paused := new(bool)
+ 	if !r.Paused.IsUnknown() && !r.Paused.IsNull() {
+ 		*paused = r.Paused.ValueBool()
+@@ -7349,3 +7359,31 @@ func (r *PipelineResourceModel) ToSharedPipelineDelete() *shared.PipelineDelete
  	}
  	return &out
  }
@@ -914,17 +925,17 @@ diff --git a/internal/sdk/pkg/models/shared/destinationtypes.go b/internal/sdk/p
 index 074f815..dd6079f 100644
 --- a/internal/sdk/pkg/models/shared/destinationtypes.go
 +++ b/internal/sdk/pkg/models/shared/destinationtypes.go
-@@ -112,7 +112,8 @@ func (u *DestinationTypes) UnmarshalJSON(data []byte) error {
- 		return nil
- 	case "DELTA_LAKE":
- 		destinationDeltaLake := new(DestinationDeltaLake)
--		if err := utils.UnmarshalJSON(data, &destinationDeltaLake, "", true, true); err != nil {
+@@ -103,7 +103,8 @@ func (u *DestinationTypes) UnmarshalJSON(data []byte) error {
+ 	switch dis.Type {
+ 	case "REDSHIFT":
+ 		destinationRedshift := new(DestinationRedshift)
+-		if err := utils.UnmarshalJSON(data, &destinationRedshift, "", true, true); err != nil {
 +		// [VIK-4496] Etleap monkey-patch: the unmarshal function allows unknown fields for ignoring schemaChangingTo and tableChangingTo
-+		if err := utils.UnmarshalJSON(data, &destinationDeltaLake, "", true, false); err != nil {
++		if err := utils.UnmarshalJSON(data, &destinationRedshift, "", true, false); err != nil {
  			return fmt.Errorf("could not unmarshal expected type: %w", err)
  		}
- 
-@@ -130,7 +131,8 @@ func (u *DestinationTypes) UnmarshalJSON(data []byte) error {
+
+@@ -112,7 +113,8 @@ func (u *DestinationTypes) UnmarshalJSON(data []byte) error {
  		return nil
  	case "SNOWFLAKE":
  		destinationSnowflake := new(DestinationSnowflake)
@@ -933,14 +944,14 @@ index 074f815..dd6079f 100644
 +		if err := utils.UnmarshalJSON(data, &destinationSnowflake, "", true, false); err != nil {
  			return fmt.Errorf("could not unmarshal expected type: %w", err)
  		}
- 
-@@ -139,7 +141,8 @@ func (u *DestinationTypes) UnmarshalJSON(data []byte) error {
+
+@@ -121,7 +123,8 @@ func (u *DestinationTypes) UnmarshalJSON(data []byte) error {
  		return nil
- 	case "REDSHIFT":
- 		destinationRedshift := new(DestinationRedshift)
--		if err := utils.UnmarshalJSON(data, &destinationRedshift, "", true, true); err != nil {
+ 	case "DELTA_LAKE":
+ 		destinationDeltaLake := new(DestinationDeltaLake)
+-		if err := utils.UnmarshalJSON(data, &destinationDeltaLake, "", true, true); err != nil {
 +		// [VIK-4496] Etleap monkey-patch: the unmarshal function allows unknown fields for ignoring schemaChangingTo and tableChangingTo
-+		if err := utils.UnmarshalJSON(data, &destinationRedshift, "", true, false); err != nil {
++		if err := utils.UnmarshalJSON(data, &destinationDeltaLake, "", true, false); err != nil {
  			return fmt.Errorf("could not unmarshal expected type: %w", err)
  		}
  


### PR DESCRIPTION
Summary                                                                                                                                                                       
                  
  - Fixes a crash (nil pointer dereference) when running terraform import on pipelines since v0.1.20
  - Root cause: commit [246433f](https://github.com/etleap/terraform-provider-etleap/commit/246433f215301ebe71cc60e499c251de44d85104) changed RefreshSchedule from value type to pointer type (*RefreshScheduleTypes) after the spec made it nullable, but
  RefreshFromSharedPipelineOutput was not updated to handle the nil case
  - Adds a nil guard in etleap.patch to initialize RefreshSchedule before accessing sub-fields during import/read
  - Also fixes drifted line numbers in etleap.patch for existing hunks (nilOutTypeField, destinationtypes.go) and removes stale go.mod/go.sum sections that are already in the generated code
  
Test plan

- Verified import fails without patch (nil pointer panic at RefreshFromSharedPipelineOutput)
- Verified import succeeds with patch (terraform import etleap_pipeline.test uLRehU3W)
- Verified git apply etleap.patch applies cleanly against current generated code  

Support Ticket: https://etleapsupport.zendesk.com/agent/tickets/28407